### PR TITLE
Fix feed search API parameter name from 'q' to 'qs'

### DIFF
--- a/src/lib/api-endpoints.ts
+++ b/src/lib/api-endpoints.ts
@@ -210,7 +210,7 @@ export const API_ENDPOINTS: ApiEndpoint[] = [
     scope: 'read-feeds',
     parameters: [
       {
-        name: 'q',
+        name: 'qs',
         type: 'string',
         required: true,
         description: 'Search query',


### PR DESCRIPTION
## Summary
Updated the feed search API endpoint parameter name to match the actual API specification.

## Changes
- Changed the search query parameter name from `q` to `qs` in the feed search endpoint definition
- This aligns the API endpoint configuration with the expected parameter name used by the backend API

## Details
The parameter name correction ensures that API clients using this endpoint definition will send requests with the correct parameter name (`qs`) rather than the incorrect one (`q`), preventing potential API errors or failed search requests.

https://claude.ai/code/session_012z1WRyw7RbJk7GxinbohQr