### PR TITLE
Refactor request selection clearing logic in history page

### DIFF
--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -29,6 +29,16 @@
     });
   }
 
+  function clearSelectedRequest() {
+    isNavigating = true;
+    const url = new URL($page.url);
+    url.searchParams.delete('request');
+    goto(url.toString(), { replaceState: true }).then(() => {
+      isNavigating = false;
+    });
+    selectedRequest = null;
+  }
+
   function generateFullUrl(request: ApiRequest): string {
     let path = request.endpoint.path;
 
@@ -64,16 +74,11 @@
         const found = $requestHistory.find((req) => req.id === requestId);
         if (found && found !== selectedRequest) {
           selectedRequest = found;
-        } else if (!found && selectedRequest) {
-          // Request not found, clear URL parameter
-          isNavigating = true;
-          const url = new URL($page.url);
-          url.searchParams.delete('request');
-          goto(url.toString(), { replaceState: true }).then(() => {
-            isNavigating = false;
-          });
-          selectedRequest = null;
+        } else if (!found) {
+          clearSelectedRequest();
         }
+      } else if (requestId && $requestHistory.length === 0) {
+        clearSelectedRequest();
       } else if (!requestId && selectedRequest) {
         selectedRequest = null;
       }


### PR DESCRIPTION
## Summary
Refactored the request selection clearing logic in the history page to reduce code duplication and improve maintainability by extracting the clearing logic into a dedicated function.

## Key Changes
- Extracted request clearing logic into a new `clearSelectedRequest()` function that handles URL parameter removal and state reset
- Replaced inline clearing code with calls to the new function, eliminating duplication
- Added handling for the edge case where a request ID is present in the URL but the request history is empty
- Simplified the conditional logic by consolidating related clearing operations

## Implementation Details
- The new `clearSelectedRequest()` function encapsulates the complete clearing workflow: setting `isNavigating` flag, removing the 'request' query parameter, navigating with `replaceState`, and resetting `selectedRequest` to null
- Updated the reactive block to call this function in two scenarios: when a requested item is not found in history, and when a request ID exists but the history is empty
- This change improves code organization and makes the clearing behavior consistent across different code paths

https://claude.ai/code/session_017H4pxtisC373tWV6NHkzyb