### PR TITLE
Fix Tokens card footer

### DIFF
--- a/src/lib/components/TokensPage.svelte
+++ b/src/lib/components/TokensPage.svelte
@@ -82,9 +82,11 @@
             </div>
           {/if}
         </div>
-        <div class="card-footer text-muted small">
-          {$tokens.length} {$tokens.length === 1 ? 'token' : 'tokens'}
-        </div>
+        {#if $tokens.length > 0}
+          <div class="card-footer border-top-0 text-muted small">
+            {$tokens.length} {$tokens.length === 1 ? 'token' : 'tokens'}
+          </div>
+        {/if}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Hide Tokens card footer when no tokens are saved
- Add `border-top-0` to `card-footer` to remove redundant border

## References

- Closes #61
- https://claude.ai/code/session_01Qu8KsQnxMGe93hGT1Dw5Mg