### PR TITLE
Add /llms.txt and /llms-full.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ vite.config.ts.timestamp-*
 .settings/
 .target/
 .vscode/
+
+# Generated LLM context
+static/llms-full.txt

--- a/docs/api-sync-workflow.md
+++ b/docs/api-sync-workflow.md
@@ -144,3 +144,19 @@ routes under `/v:version/` in the Koa router. The `validateApiVersion`
 middleware accepts any positive integer (`/v1/`, `/v2/`, `/v99/` all hit the
 same handlers). The extraction script normalizes to `/v2/` (the version
 declared in the server docs). The explorer app can use any version number.
+
+## LLM-readable reference
+
+`static/llms-full.txt` is auto-generated from `src/lib/freefeed-api.json` by
+`scripts/generate-llms-txt.mjs`. Do not edit it manually.
+
+The file is regenerated on every production build (`npm run build`). To
+regenerate manually:
+
+```bash
+npm run llms:generate
+```
+
+`static/llms.txt` is a hand-written overview file per the
+[llmstxt.org](https://llmstxt.org/) spec. Edit it directly when the project
+description or links change.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "npm run llms:generate && vite build",
     "preview": "vite preview",
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "api:check": "node scripts/check-api-changes.mjs"
+    "api:check": "node scripts/check-api-changes.mjs",
+    "llms:generate": "node scripts/generate-llms-txt.mjs"
   },
   "dependencies": {
     "@zerodevx/svelte-json-view": "^1.0.11",

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -23,7 +23,7 @@ export function generateMarkdown(apiData) {
   lines.push('');
   lines.push(`> Source: [${meta.server_repo}](https://github.com/${meta.server_repo}) (${meta.server_branch} branch)`);
   lines.push(
-    `> Synced: ${meta.synced_at} | ${meta.total_endpoints} endpoints | [Interactive explorer](https://freefeed-api-explorer.pages.dev)`
+    `> Synced: ${meta.synced_at} | ${endpoints.length} endpoints | [Interactive explorer](https://freefeed-api-explorer.pages.dev)`
   );
   lines.push('');
   lines.push('## Endpoints');

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -78,5 +78,5 @@ if (isMain) {
   const apiData = JSON.parse(readFileSync(API_JSON, 'utf-8'));
   const markdown = generateMarkdown(apiData);
   writeFileSync(OUTPUT, markdown);
-  process.stderr.write(`Generated ${OUTPUT} (${apiData.meta.total_endpoints} endpoints)\n`);
+  process.stderr.write(`Generated ${OUTPUT} (${apiData.endpoints.length} endpoints)\n`);
 }

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Generate static/llms-full.txt from src/lib/freefeed-api.json.
+ *
+ * Usage: node scripts/generate-llms-txt.mjs
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = fileURLToPath(new URL('.', import.meta.url));
+const PROJECT_DIR = join(SCRIPT_DIR, '..');
+const API_JSON = join(PROJECT_DIR, 'src', 'lib', 'freefeed-api.json');
+const OUTPUT = join(PROJECT_DIR, 'static', 'llms-full.txt');
+
+export function generateMarkdown(apiData) {
+  const { meta, endpoints } = apiData;
+  const lines = [];
+
+  lines.push('# FreeFeed API Reference');
+  lines.push('');
+  lines.push(`> Source: [${meta.server_repo}](https://github.com/${meta.server_repo}) (${meta.server_branch} branch)`);
+  lines.push(
+    `> Synced: ${meta.synced_at} | ${meta.total_endpoints} endpoints | [Interactive explorer](https://freefeed-api-explorer.pages.dev)`
+  );
+  lines.push('');
+  lines.push('## Endpoints');
+
+  // Group by path prefix: /v2/segment
+  const groups = new Map();
+  for (const ep of endpoints) {
+    const prefix = getGroupPrefix(ep.path);
+    if (!groups.has(prefix)) groups.set(prefix, []);
+    groups.get(prefix).push(ep);
+  }
+
+  for (const [prefix, eps] of groups) {
+    lines.push('');
+    lines.push(`### ${prefix}`);
+
+    for (const ep of eps) {
+      lines.push('');
+      lines.push(`#### ${ep.method} ${ep.path}`);
+      lines.push('');
+      lines.push(ep.description);
+      lines.push('');
+      lines.push(`- Auth required: ${ep.auth_required ? 'yes' : 'no'}`);
+      lines.push(`- Scopes: ${ep.scopes.map((s) => '`' + s + '`').join(', ')}`);
+
+      if (ep.parameters.length > 0) {
+        lines.push('');
+        lines.push('| Parameter | Location | Type | Required | Description |');
+        lines.push('|-----------|----------|------|----------|-------------|');
+        for (const p of ep.parameters) {
+          lines.push(
+            `| ${p.name} | ${p.location} | ${p.type} | ${p.required ? 'yes' : 'no'} | ${p.description || ''} |`
+          );
+        }
+      }
+    }
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+
+function getGroupPrefix(path) {
+  // "/v2/posts/:postId/comments" → "/v2/posts"
+  const parts = path.split('/');
+  // parts: ['', 'v2', 'posts', ':postId', 'comments']
+  // Take up to index 3 (first two real segments: v2 + resource)
+  return '/' + parts.slice(1, 3).join('/');
+}
+
+// Run as CLI
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  const apiData = JSON.parse(readFileSync(API_JSON, 'utf-8'));
+  const markdown = generateMarkdown(apiData);
+  writeFileSync(OUTPUT, markdown);
+  process.stderr.write(`Generated ${OUTPUT} (${apiData.meta.total_endpoints} endpoints)\n`);
+}

--- a/scripts/generate-llms-txt.mjs
+++ b/scripts/generate-llms-txt.mjs
@@ -22,9 +22,7 @@ export function generateMarkdown(apiData) {
   lines.push('# FreeFeed API Reference');
   lines.push('');
   lines.push(`> Source: [${meta.server_repo}](https://github.com/${meta.server_repo}) (${meta.server_branch} branch)`);
-  lines.push(
-    `> Synced: ${meta.synced_at} | ${endpoints.length} endpoints | [Interactive explorer](https://freefeed-api-explorer.pages.dev)`
-  );
+  lines.push(`> Synced: ${meta.synced_at} | ${endpoints.length} endpoints`);
   lines.push('');
   lines.push('## Endpoints');
 

--- a/scripts/generate-llms-txt.test.mjs
+++ b/scripts/generate-llms-txt.test.mjs
@@ -1,0 +1,112 @@
+// @vitest-environment node
+
+import { describe, test, expect } from 'vitest';
+import { generateMarkdown } from './generate-llms-txt.mjs';
+
+const sampleData = {
+  meta: {
+    server_repo: 'FreeFeed/freefeed-server',
+    server_branch: 'stable',
+    server_rev: 'abc123',
+    synced_at: '2026-04-06',
+    total_endpoints: 3,
+    format_version: 1,
+  },
+  endpoints: [
+    {
+      method: 'GET',
+      path: '/v2/posts',
+      description: 'Get posts.',
+      auth_required: true,
+      scopes: ['read-feeds'],
+      parameters: [],
+    },
+    {
+      method: 'GET',
+      path: '/v2/posts/:postId',
+      description: 'Get a single post.',
+      auth_required: false,
+      scopes: ['read-feeds'],
+      parameters: [
+        {
+          name: 'postId',
+          location: 'path',
+          type: 'string',
+          required: true,
+          description: 'Post UUID',
+        },
+      ],
+    },
+    {
+      method: 'POST',
+      path: '/v2/users/login',
+      description: 'Log in.',
+      auth_required: false,
+      scopes: ['any'],
+      parameters: [
+        {
+          name: 'username',
+          location: 'body',
+          type: 'string',
+          required: true,
+          description: 'Username',
+        },
+        {
+          name: 'password',
+          location: 'body',
+          type: 'string',
+          required: true,
+          description: 'Password',
+        },
+      ],
+    },
+  ],
+};
+
+describe('generateMarkdown', () => {
+  const md = generateMarkdown(sampleData);
+
+  test('starts with title', () => {
+    expect(md).toMatch(/^# FreeFeed API Reference/);
+  });
+
+  test('includes meta info', () => {
+    expect(md).toContain('FreeFeed/freefeed-server');
+    expect(md).toContain('2026-04-06');
+    expect(md).toContain('3 endpoints');
+  });
+
+  test('groups endpoints by path prefix', () => {
+    expect(md).toContain('### /v2/posts');
+    expect(md).toContain('### /v2/users');
+  });
+
+  test('renders endpoint headings', () => {
+    expect(md).toContain('#### GET /v2/posts');
+    expect(md).toContain('#### GET /v2/posts/:postId');
+    expect(md).toContain('#### POST /v2/users/login');
+  });
+
+  test('renders descriptions', () => {
+    expect(md).toContain('Get posts.');
+    expect(md).toContain('Get a single post.');
+    expect(md).toContain('Log in.');
+  });
+
+  test('renders auth and scope info', () => {
+    expect(md).toContain('- Auth required: yes');
+    expect(md).toContain('- Auth required: no');
+    expect(md).toContain('`read-feeds`');
+  });
+
+  test('renders parameter tables', () => {
+    expect(md).toContain('| postId | path | string | yes | Post UUID |');
+    expect(md).toContain('| username | body | string | yes | Username |');
+  });
+
+  test('omits parameter table for endpoints with no parameters', () => {
+    // GET /v2/posts has no params — there should be no table header immediately after its scope line
+    const getPostsSection = md.split('#### GET /v2/posts\n')[1].split('####')[0];
+    expect(getPostsSection).not.toContain('| Parameter |');
+  });
+});

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -6,4 +6,4 @@ FreeFeed is an open-source social network. This site provides a browsable refere
 
 ## API Reference
 
-- [Full API reference (llms-full.txt)](https://freefeed-api-explorer.pages.dev/llms-full.txt): Complete endpoint reference with parameters
+- [Full API reference](llms-full.txt): Complete endpoint reference with parameters

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,9 +1,5 @@
 # FreeFeed API Explorer
 
-> FreeFeed API Explorer is an interactive tool for browsing the FreeFeed social network API.
-
 FreeFeed is an open-source social network. This site provides a browsable reference for all public API endpoints, including HTTP methods, paths, parameters, authentication requirements, and access scopes.
 
-## API Reference
-
-- [Full API reference](llms-full.txt): Complete endpoint reference with parameters
+Full API reference: /llms-full.txt

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,9 @@
+# FreeFeed API Explorer
+
+> FreeFeed API Explorer is an interactive tool for browsing the FreeFeed social network API.
+
+FreeFeed is an open-source social network. This site provides a browsable reference for all public API endpoints, including HTTP methods, paths, parameters, authentication requirements, and access scopes.
+
+## API Reference
+
+- [Full API reference (llms-full.txt)](https://freefeed-api-explorer.pages.dev/llms-full.txt): Complete endpoint reference with parameters

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   plugins: [sveltekit()],
   test: {
     environment: 'jsdom',
-    include: ['src/**/*.{test,spec}.{js,ts}'],
+    include: ['src/**/*.{test,spec}.{js,ts}', 'scripts/**/*.{test,spec}.{js,mjs}'],
     setupFiles: ['src/setupTests.ts'],
   },
 });


### PR DESCRIPTION
## Summary

- Add hand-written `static/llms.txt` overview per [llmstxt.org](https://llmstxt.org/) spec
- Add `scripts/generate-llms-txt.mjs` to generate `static/llms-full.txt` (complete API reference in markdown) from `freefeed-api.json`
- Wire generation into `npm run build` so production builds always have fresh output
- Document the generation workflow in `docs/api-sync-workflow.md`

## References

- Closes #59