### PR TITLE
Fix mobile navigation with unified drawer

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -75,6 +75,21 @@
           display: none;
         }
       }
+
+      /* Keep the navbar above the offcanvas + backdrop so it stays visible
+         (and its brand serves as the drawer's header — no duplicated title). */
+      .site-navbar {
+        position: sticky;
+        top: 0;
+        z-index: 1050;
+      }
+      .sidebar-offcanvas.offcanvas-start {
+        top: var(--nav-h, 56px);
+        height: calc(100dvh - var(--nav-h, 56px));
+      }
+      .offcanvas-backdrop {
+        top: var(--nav-h, 56px);
+      }
     </style>
     %sveltekit.head%
   </head>

--- a/src/app.html
+++ b/src/app.html
@@ -55,14 +55,33 @@
         padding-bottom: 2rem;
       }
 
-      /* Responsive: stack columns on mobile */
+      /* Responsive: stack columns on mobile and let the page scroll
+         as one document instead of locking scroll inside each column. */
       @media (max-width: 767.98px) {
+        html,
+        body,
+        main {
+          height: auto;
+          min-height: 100dvh;
+        }
+
+        main:has(.split-layout) {
+          overflow: visible;
+        }
+
         .split-layout {
           flex-direction: column;
+          min-height: 0;
         }
 
         .split-sidebar {
           width: auto;
+        }
+
+        .scrollable-column {
+          height: auto;
+          overflow-y: visible;
+          padding-bottom: 0;
         }
 
         .hide-below-md {

--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -4,18 +4,33 @@
   let { currentPage = 'home' }: { currentPage?: 'home' | 'history' | 'requests' | 'tokens' | 'about' } = $props();
 
   const environment = env.PUBLIC_ENVIRONMENT || 'development';
+
+  let navEl: HTMLElement | undefined = $state();
+
+  // Keep --nav-h in sync with the navbar's rendered height so the offcanvas
+  // and its backdrop sit precisely below it regardless of font size or zoom.
+  $effect(() => {
+    if (!navEl) return;
+    const update = () => {
+      document.documentElement.style.setProperty('--nav-h', `${navEl!.offsetHeight}px`);
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(navEl);
+    return () => observer.disconnect();
+  });
 </script>
 
-<nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
+<nav bind:this={navEl} class="navbar bg-primary site-navbar" data-bs-theme="dark">
   <div class="container-fluid">
     <div class="d-flex align-items-center">
       <button
-        class="btn text-light show-below-md me-2 p-1"
+        class="btn text-light nav-hamburger me-2 p-1"
         type="button"
         data-bs-toggle="offcanvas"
         data-bs-target="#sidebarOffcanvas"
         aria-controls="sidebarOffcanvas"
-        aria-label="Browse endpoints"
+        aria-label="Open menu"
       >
         <i class="bi bi-list fs-4"></i>
       </button>
@@ -23,7 +38,7 @@
       {#if environment === 'staging'}
         <span class="badge bg-warning text-dark ms-2">STAGING</span>
       {/if}
-      <div class="navbar-nav ms-3">
+      <div class="navbar-nav nav-inline ms-3 flex-row gap-3">
         <a href="/requests" class="nav-link" class:active={currentPage === 'requests'}>Requests</a>
         <a href="/history" class="nav-link" class:active={currentPage === 'history'}>History</a>
         <a href="/tokens" class="nav-link" class:active={currentPage === 'tokens'}>Tokens</a>
@@ -32,3 +47,18 @@
     </div>
   </div>
 </nav>
+
+<style>
+  /* Below md: hide inline links (use offcanvas drawer instead). */
+  @media (max-width: 767.98px) {
+    .nav-inline {
+      display: none !important;
+    }
+  }
+  /* md and up: hide the hamburger (links + persistent sidebar are inline). */
+  @media (min-width: 768px) {
+    .nav-hamburger {
+      display: none !important;
+    }
+  }
+</style>

--- a/src/lib/components/RequestsPage.svelte
+++ b/src/lib/components/RequestsPage.svelte
@@ -94,15 +94,6 @@
     }
   });
 
-  function closeOffcanvas() {
-    if (typeof window !== 'undefined') {
-      const el = document.getElementById('sidebarOffcanvas');
-      // @ts-expect-error - Bootstrap is loaded via CDN
-      const offcanvas = window.bootstrap.Offcanvas.getInstance(el);
-      offcanvas?.hide();
-    }
-  }
-
   function selectEndpoint(endpoint: ApiEndpoint) {
     selectedEndpoint = endpoint;
     parameters = {};
@@ -445,7 +436,7 @@
                     <i class="bi bi-exclamation-triangle"></i>
                     No tokens configured —
                     <a href="/tokens">add one</a>
-                     to start making API requests.
+                    to start making API requests.
                   </div>
                 {/if}
                 <div class="d-flex align-items-center gap-2 flex-wrap">
@@ -487,7 +478,9 @@
               </div>
             {:else if activeTab === 'fetch'}
               <div class="tab-pane active" role="tabpanel">
-                <pre class="m-0 p-2 rounded small"><code bind:this={fetchCodeEl} class="language-javascript"></code></pre>
+                <pre class="m-0 p-2 rounded small"><code
+                    bind:this={fetchCodeEl}
+                    class="language-javascript"></code></pre>
               </div>
             {:else if activeTab === 'curl'}
               <div class="tab-pane active" role="tabpanel">
@@ -504,37 +497,6 @@
           </div>
         </div>
       {/if}
-    </div>
-  </div>
-</div>
-
-<!-- Mobile Offcanvas Sidebar -->
-<div class="offcanvas offcanvas-start" tabindex="-1" id="sidebarOffcanvas" aria-labelledby="sidebarOffcanvasLabel">
-  <div class="offcanvas-header">
-    <h5 class="offcanvas-title" id="sidebarOffcanvasLabel">API Endpoints</h5>
-    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-  </div>
-  <div class="offcanvas-body p-0">
-    <div class="p-3">
-      <input type="text" class="form-control mb-2" placeholder="Search endpoints..." bind:value={$searchQuery} />
-      <select class="form-select" bind:value={$selectedScope}>
-        <option value="">All Scopes</option>
-        {#each scopes as scope}
-          <option value={scope}>{scope}</option>
-        {/each}
-      </select>
-    </div>
-    <div class="list-group list-group-flush border-top">
-      {#each filteredEndpoints as endpoint}
-        <RequestListItem
-          {endpoint}
-          isSelected={selectedEndpoint?.path === endpoint.path && selectedEndpoint?.method === endpoint.method}
-          onClick={() => {
-            selectEndpoint(endpoint);
-            closeOffcanvas();
-          }}
-        />
-      {/each}
     </div>
   </div>
 </div>

--- a/src/lib/components/SidebarOffcanvas.svelte
+++ b/src/lib/components/SidebarOffcanvas.svelte
@@ -3,9 +3,10 @@
   import { goto } from '$app/navigation';
   import type { ApiEndpoint } from '$lib/types.js';
   import { API_ENDPOINTS } from '$lib/api-endpoints.js';
-  import { searchQuery, selectedScope } from '$lib/stores.js';
-  import { endpointToId, idToEndpoint } from '$lib/utils.js';
+  import { requestHistory, searchQuery, selectedScope } from '$lib/stores.js';
+  import { endpointToId, getRelativeTime, idToEndpoint } from '$lib/utils.js';
   import RequestListItem from './RequestListItem.svelte';
+  import ResponseStatus from './ResponseStatus.svelte';
 
   const navLinks = [
     { href: '/requests', label: 'Requests', icon: 'bi-send' },
@@ -17,14 +18,16 @@
   const scopes = [...new Set(API_ENDPOINTS.flatMap((e) => e.scopes))].sort();
 
   let currentPath = $derived($page.url.pathname);
+  let isHistoryPage = $derived(currentPath === '/history');
+  let isRequestsPage = $derived(currentPath === '/' || currentPath === '/requests');
 
   function isActivePath(href: string): boolean {
-    if (href === '/requests') return currentPath === '/' || currentPath === '/requests';
+    if (href === '/requests') return isRequestsPage;
     return currentPath === href;
   }
 
   let selectedEndpoint = $derived.by((): ApiEndpoint | null => {
-    if (currentPath !== '/' && currentPath !== '/requests') return null;
+    if (!isRequestsPage) return null;
     const endpointParam = $page.url.searchParams.get('endpoint');
     if (!endpointParam) return null;
     let found = idToEndpoint(endpointParam, API_ENDPOINTS);
@@ -34,6 +37,8 @@
     }
     return found;
   });
+
+  let selectedRequestId = $derived(isHistoryPage ? $page.url.searchParams.get('request') : null);
 
   let filteredEndpoints = $derived(
     API_ENDPOINTS.filter((endpoint) => {
@@ -57,13 +62,20 @@
 
   async function selectEndpoint(endpoint: ApiEndpoint) {
     const id = endpointToId(endpoint);
-    if (currentPath === '/' || currentPath === '/requests') {
+    if (isRequestsPage) {
       const url = new URL($page.url);
       url.searchParams.set('endpoint', id);
       await goto(url.toString(), { replaceState: true });
     } else {
       await goto(`/requests?endpoint=${id}`);
     }
+    closeOffcanvas();
+  }
+
+  async function selectHistoryRequest(requestId: string) {
+    const url = new URL($page.url);
+    url.searchParams.set('request', requestId);
+    await goto(url.toString(), { replaceState: true });
     closeOffcanvas();
   }
 </script>
@@ -74,7 +86,7 @@
   id="sidebarOffcanvas"
   aria-labelledby="sidebarOffcanvasLabel"
 >
-  <h5 id="sidebarOffcanvasLabel" class="visually-hidden">Navigation and API endpoints</h5>
+  <h5 id="sidebarOffcanvasLabel" class="visually-hidden">Navigation menu</h5>
   <div class="offcanvas-body p-0">
     <!-- Page navigation -->
     <div class="list-group list-group-flush drawer-nav">
@@ -91,30 +103,52 @@
       {/each}
     </div>
 
-    <!-- API endpoints search + list -->
-    <div class="p-3 border-top">
-      <input
-        type="text"
-        class="form-control mb-2"
-        placeholder="Search endpoints..."
-        bind:value={$searchQuery}
-      />
-      <select class="form-select" bind:value={$selectedScope}>
-        <option value="">All Scopes</option>
-        {#each scopes as scope}
-          <option value={scope}>{scope}</option>
+    {#if isHistoryPage}
+      <!-- Request history -->
+      <div class="list-group list-group-flush border-top">
+        {#each $requestHistory as request (request.id)}
+          <RequestListItem
+            endpoint={request.endpoint}
+            isSelected={selectedRequestId === request.id}
+            onClick={() => selectHistoryRequest(request.id)}
+          >
+            {#snippet sideContent()}
+              {#if request.response}
+                <p class="mb-1">
+                  <ResponseStatus status={request.response.status} />
+                </p>
+              {/if}
+              <p class="mb-0 small">{getRelativeTime(request.timestamp)}</p>
+            {/snippet}
+          </RequestListItem>
         {/each}
-      </select>
-    </div>
-    <div class="list-group list-group-flush border-top">
-      {#each filteredEndpoints as endpoint}
-        <RequestListItem
-          {endpoint}
-          isSelected={selectedEndpoint?.path === endpoint.path && selectedEndpoint?.method === endpoint.method}
-          onClick={() => selectEndpoint(endpoint)}
+      </div>
+    {:else}
+      <!-- API endpoints search + list -->
+      <div class="p-3 border-top">
+        <input
+          type="text"
+          class="form-control mb-2"
+          placeholder="Search endpoints..."
+          bind:value={$searchQuery}
         />
-      {/each}
-    </div>
+        <select class="form-select" bind:value={$selectedScope}>
+          <option value="">All Scopes</option>
+          {#each scopes as scope}
+            <option value={scope}>{scope}</option>
+          {/each}
+        </select>
+      </div>
+      <div class="list-group list-group-flush border-top">
+        {#each filteredEndpoints as endpoint}
+          <RequestListItem
+            {endpoint}
+            isSelected={selectedEndpoint?.path === endpoint.path && selectedEndpoint?.method === endpoint.method}
+            onClick={() => selectEndpoint(endpoint)}
+          />
+        {/each}
+      </div>
+    {/if}
   </div>
 </div>
 

--- a/src/lib/components/SidebarOffcanvas.svelte
+++ b/src/lib/components/SidebarOffcanvas.svelte
@@ -1,0 +1,130 @@
+<script lang="ts">
+  import { page } from '$app/stores';
+  import { goto } from '$app/navigation';
+  import type { ApiEndpoint } from '$lib/types.js';
+  import { API_ENDPOINTS } from '$lib/api-endpoints.js';
+  import { searchQuery, selectedScope } from '$lib/stores.js';
+  import { endpointToId, idToEndpoint } from '$lib/utils.js';
+  import RequestListItem from './RequestListItem.svelte';
+
+  const navLinks = [
+    { href: '/requests', label: 'Requests', icon: 'bi-send' },
+    { href: '/history', label: 'History', icon: 'bi-clock-history' },
+    { href: '/tokens', label: 'Tokens', icon: 'bi-key' },
+    { href: '/about', label: 'About', icon: 'bi-info-circle' },
+  ];
+
+  const scopes = [...new Set(API_ENDPOINTS.flatMap((e) => e.scopes))].sort();
+
+  let currentPath = $derived($page.url.pathname);
+
+  function isActivePath(href: string): boolean {
+    if (href === '/requests') return currentPath === '/' || currentPath === '/requests';
+    return currentPath === href;
+  }
+
+  let selectedEndpoint = $derived.by((): ApiEndpoint | null => {
+    if (currentPath !== '/' && currentPath !== '/requests') return null;
+    const endpointParam = $page.url.searchParams.get('endpoint');
+    if (!endpointParam) return null;
+    let found = idToEndpoint(endpointParam, API_ENDPOINTS);
+    if (!found && endpointParam.includes(':')) {
+      const [method, path] = endpointParam.split(':', 2);
+      found = API_ENDPOINTS.find((ep) => ep.method === method && ep.path === path) || null;
+    }
+    return found;
+  });
+
+  let filteredEndpoints = $derived(
+    API_ENDPOINTS.filter((endpoint) => {
+      const matchesSearch =
+        !$searchQuery ||
+        endpoint.path.toLowerCase().includes($searchQuery.toLowerCase()) ||
+        endpoint.description.toLowerCase().includes($searchQuery.toLowerCase());
+      const matchesScope = !$selectedScope || endpoint.scopes.includes($selectedScope);
+      return matchesSearch && matchesScope;
+    })
+  );
+
+  function closeOffcanvas() {
+    if (typeof window === 'undefined') return;
+    const el = document.getElementById('sidebarOffcanvas');
+    if (!el) return;
+    // @ts-expect-error - Bootstrap is loaded via CDN
+    const offcanvas = window.bootstrap?.Offcanvas.getInstance(el);
+    offcanvas?.hide();
+  }
+
+  async function selectEndpoint(endpoint: ApiEndpoint) {
+    const id = endpointToId(endpoint);
+    if (currentPath === '/' || currentPath === '/requests') {
+      const url = new URL($page.url);
+      url.searchParams.set('endpoint', id);
+      await goto(url.toString(), { replaceState: true });
+    } else {
+      await goto(`/requests?endpoint=${id}`);
+    }
+    closeOffcanvas();
+  }
+</script>
+
+<div
+  class="offcanvas offcanvas-start sidebar-offcanvas"
+  tabindex="-1"
+  id="sidebarOffcanvas"
+  aria-labelledby="sidebarOffcanvasLabel"
+>
+  <h5 id="sidebarOffcanvasLabel" class="visually-hidden">Navigation and API endpoints</h5>
+  <div class="offcanvas-body p-0">
+    <!-- Page navigation -->
+    <div class="list-group list-group-flush drawer-nav">
+      {#each navLinks as link}
+        <a
+          href={link.href}
+          class="list-group-item list-group-item-action"
+          class:active={isActivePath(link.href)}
+          onclick={closeOffcanvas}
+        >
+          <i class="bi {link.icon} me-2"></i>
+          {link.label}
+        </a>
+      {/each}
+    </div>
+
+    <!-- API endpoints search + list -->
+    <div class="p-3 border-top">
+      <input
+        type="text"
+        class="form-control mb-2"
+        placeholder="Search endpoints..."
+        bind:value={$searchQuery}
+      />
+      <select class="form-select" bind:value={$selectedScope}>
+        <option value="">All Scopes</option>
+        {#each scopes as scope}
+          <option value={scope}>{scope}</option>
+        {/each}
+      </select>
+    </div>
+    <div class="list-group list-group-flush border-top">
+      {#each filteredEndpoints as endpoint}
+        <RequestListItem
+          {endpoint}
+          isSelected={selectedEndpoint?.path === endpoint.path && selectedEndpoint?.method === endpoint.method}
+          onClick={() => selectEndpoint(endpoint)}
+        />
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  /* Page-nav active item: transparent + bold so it doesn't clash with the
+     primary-blue navbar above the drawer. */
+  .drawer-nav :global(.list-group-item.active) {
+    background-color: transparent;
+    color: var(--bs-body-color);
+    border-color: var(--bs-border-color);
+    font-weight: 600;
+  }
+</style>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,11 @@
-<script>
+<script lang="ts">
+  import SidebarOffcanvas from '$lib/components/SidebarOffcanvas.svelte';
+
   let { children } = $props();
 </script>
 
 <main>
   {@render children()}
 </main>
+
+<SidebarOffcanvas />

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -92,8 +92,8 @@
 <NavigationBar currentPage="history" />
 
 <div class="split-layout">
-  <!-- Left Sidebar: Request History -->
-  <div class="split-sidebar border-end">
+  <!-- Left Sidebar: Request History (desktop only — drawer on mobile) -->
+  <div class="split-sidebar hide-below-md border-end">
     <div class="scrollable-column">
       <div class="p-3 border-bottom d-flex justify-content-between align-items-center">
         <h5 class="mb-0">Request History</h5>
@@ -180,10 +180,10 @@
         <!-- Response -->
         <Response request={selectedRequest} />
       {:else}
-        <div class="card d-none d-md-block">
+        <div class="card">
           <div class="card-body text-center text-muted py-5">
             <h3>Request History</h3>
-            <p>Select a request from the sidebar to view its details.</p>
+            <p>Select a request to view its details.</p>
             {#if $requestHistory.length === 0}
               <p class="small">
                 No requests found. <a href="/">Start exploring the API</a>


### PR DESCRIPTION
## Summary

- Move the offcanvas to the layout level so the hamburger works on every page (previously it lived inside `RequestsPage` and did nothing elsewhere).
- Consolidate page nav + the page's resource list into one drawer, anchored under a sticky navbar that frames it visually (no duplicated title).
- Replace the broken `navbar-expand-lg` behavior with proper responsive switching: inline links ≥md, hamburger <md.
- Drawer content swaps by page: API endpoints on `/requests`, request history on `/history`. Selecting an item updates the URL and closes the drawer.
- Let stacked split-layout pages scroll the document on mobile instead of locking scroll inside each column.
