### PR TITLE
Refine UI text per #56

### DIFF
--- a/src/lib/components/RequestsPage.svelte
+++ b/src/lib/components/RequestsPage.svelte
@@ -434,9 +434,9 @@
                 {#if $tokens.length === 0}
                   <div class="alert alert-warning small mb-3" role="alert">
                     <i class="bi bi-exclamation-triangle"></i>
-                    No tokens configured —
+                    No tokens yet —
                     <a href="/tokens">add one</a>
-                    to start making API requests.
+                     to make requests.
                   </div>
                 {/if}
                 <div class="d-flex align-items-center gap-2 flex-wrap">
@@ -493,7 +493,7 @@
         <div class="card">
           <div class="card-body text-center text-muted py-5">
             <h3>Welcome to FreeFeed API Explorer</h3>
-            <p>Select an API endpoint from the sidebar to get started.</p>
+            <p>Select an endpoint to begin.</p>
           </div>
         </div>
       {/if}

--- a/src/lib/components/RequestsPage.svelte
+++ b/src/lib/components/RequestsPage.svelte
@@ -436,7 +436,7 @@
                     <i class="bi bi-exclamation-triangle"></i>
                     No tokens yet —
                     <a href="/tokens">add one</a>
-                     to make requests.
+                    to make requests.
                   </div>
                 {/if}
                 <div class="d-flex align-items-center gap-2 flex-wrap">

--- a/src/lib/components/TokenModal.svelte
+++ b/src/lib/components/TokenModal.svelte
@@ -52,9 +52,8 @@
       </div>
       <div class="modal-body">
         <div class="alert alert-info">
-          <strong>Privacy Notice:</strong>
-          Your token is stored locally in your browser's localStorage and will not be sent to any third-party servers except
-          when making API requests to the selected FreeFeed instance.
+          <strong>Privacy:</strong>
+          Tokens are stored in your browser's localStorage and sent only to the selected FreeFeed instance.
         </div>
         <div class="mb-3">
           <label for="title-input" class="form-label">Title</label>
@@ -63,7 +62,7 @@
             type="text"
             class="form-control"
             bind:value={titleInput}
-            placeholder="Optional description"
+            placeholder="Optional nickname"
           />
         </div>
         <div class="mb-3">
@@ -73,7 +72,7 @@
             type="password"
             class="form-control"
             bind:value={tokenInput}
-            placeholder="Enter your FreeFeed API token..."
+            placeholder="Paste API token"
           />
         </div>
         <div class="mb-3">
@@ -95,7 +94,7 @@
           disabled={!tokenInput}
           onclick={saveToken}
         >
-          Save Configuration
+          Save Token
         </button>
       </div>
     </div>

--- a/src/lib/components/TokensPage.svelte
+++ b/src/lib/components/TokensPage.svelte
@@ -27,10 +27,7 @@
         </div>
         <div class="card-body p-0">
           {#if $tokens.length === 0}
-            <p class="text-center text-muted py-4 mb-0">
-              No tokens saved yet. Click <strong>Create Token</strong>
-               to get started.
-            </p>
+            <p class="text-center text-muted py-4 mb-0">No tokens saved yet.</p>
           {:else}
             <div class="table-responsive">
               <table class="table table-hover align-middle mb-0">
@@ -53,7 +50,7 @@
                         {#if $validatingTokenIds.has(token.id)}
                           <span class="text-muted">
                             <i class="bi bi-arrow-repeat spin"></i>
-                             Validating…
+                            Validating…
                           </span>
                         {:else if $validationResults[token.id]}
                           {@const result = $validationResults[token.id]}
@@ -65,12 +62,12 @@
                           {:else if result.status === 'invalid'}
                             <span class="text-danger" title="Validated at {formatDate(result.validatedAt)}">
                               <i class="bi bi-x-circle-fill"></i>
-                               Invalid
+                              Invalid
                             </span>
                           {:else}
                             <span class="text-warning" title={result.message}>
                               <i class="bi bi-exclamation-triangle-fill"></i>
-                               Error
+                              Error
                             </span>
                           {/if}
                         {:else}

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -16,28 +16,29 @@
           <h3 class="mb-0">About FreeFeed API Explorer</h3>
         </div>
         <div class="card-body">
-          <p class="lead">A web-based tool for exploring and testing the FreeFeed API endpoints.</p>
+          <p class="lead">A web-based tool for exploring and testing the FreeFeed API.</p>
 
-          <p>
-            This application allows you to browse available API endpoints, execute requests with custom parameters, and
-            view responses in a clean interface. It includes features like:
-          </p>
+          <p>Features:</p>
 
           <ul>
-            <li>Interactive API endpoint browser with search and filtering</li>
-            <li>Parameter input forms with validation</li>
-            <li>Request execution with real-time responses</li>
-            <li>Code generation for fetch() and curl commands</li>
-            <li>Request history tracking</li>
-            <li>Local storage for tokens and preferences</li>
+            <li>Endpoint browser with search and scope filtering</li>
+            <li>Parameter forms with type-aware inputs</li>
+            <li>Request execution against any FreeFeed instance</li>
+            <li>
+              Generated <code>fetch()</code>
+              and
+              <code>curl</code>
+               snippets
+            </li>
+            <li>Request history with response inspection</li>
+            <li>Multiple tokens and instances, managed locally</li>
           </ul>
 
-          <p>Built with SvelteKit, TypeScript, and Bootstrap 5. This is an open-source project available on GitHub.</p>
+          <p>Built with SvelteKit, TypeScript, and Bootstrap 5. Open source.</p>
 
           <p>
-            <strong>Privacy & Security:</strong>
-             All data is stored locally in your browser and no information is sent to third-party services except when making
-            API requests to FreeFeed instances.
+            <strong>Privacy:</strong>
+            Tokens, history, and preferences stay in your browser. Requests go directly to the selected FreeFeed instance.
           </p>
 
           <div class="mt-4">

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -18,22 +18,6 @@
         <div class="card-body">
           <p class="lead">A web-based tool for exploring and testing the FreeFeed API.</p>
 
-          <p>Features:</p>
-
-          <ul>
-            <li>Endpoint browser with search and scope filtering</li>
-            <li>Parameter forms with type-aware inputs</li>
-            <li>Request execution against any FreeFeed instance</li>
-            <li>
-              Generated <code>fetch()</code>
-              and
-              <code>curl</code>
-               snippets
-            </li>
-            <li>Request history with response inspection</li>
-            <li>Multiple tokens and instances, managed locally</li>
-          </ul>
-
           <p>Built with SvelteKit, TypeScript, and Bootstrap 5. Open source.</p>
 
           <p>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -183,13 +183,7 @@
         <div class="card">
           <div class="card-body text-center text-muted py-5">
             <h3>Request History</h3>
-            <p>Select a request to view its details.</p>
-            {#if $requestHistory.length === 0}
-              <p class="small">
-                No requests found. <a href="/">Start exploring the API</a>
-                to build your request history.
-              </p>
-            {/if}
+            <p>Select a request to see details.</p>
           </div>
         </div>
       {/if}


### PR DESCRIPTION
## Summary

- Empty states no longer instruct the user to "click X" or "go to Y" — the action button is already in view.
- History main panel drops a duplicate "no requests found" line that mirrored the sidebar.
- TokenModal phrasing tightened ("Save Token", concise privacy notice, simpler placeholders).
- /about page trimmed: feature list removed (apparent from using the app), privacy paragraph condensed.

## References

- Closes #56
