### PR TITLE
Add Agents page for LLM agent discovery

### DIFF
--- a/src/lib/components/NavigationBar.svelte
+++ b/src/lib/components/NavigationBar.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import { env } from '$env/dynamic/public';
 
-  let { currentPage = 'home' }: { currentPage?: 'home' | 'history' | 'requests' | 'tokens' | 'about' } = $props();
+  let { currentPage = 'home' }: { currentPage?: 'home' | 'history' | 'requests' | 'tokens' | 'agents' | 'about' } =
+    $props();
 
   const environment = env.PUBLIC_ENVIRONMENT || 'development';
 
@@ -42,6 +43,7 @@
         <a href="/requests" class="nav-link" class:active={currentPage === 'requests'}>Requests</a>
         <a href="/history" class="nav-link" class:active={currentPage === 'history'}>History</a>
         <a href="/tokens" class="nav-link" class:active={currentPage === 'tokens'}>Tokens</a>
+        <a href="/agents" class="nav-link" class:active={currentPage === 'agents'}>Agents</a>
         <a href="/about" class="nav-link" class:active={currentPage === 'about'}>About</a>
       </div>
     </div>

--- a/src/lib/components/SidebarOffcanvas.svelte
+++ b/src/lib/components/SidebarOffcanvas.svelte
@@ -12,6 +12,7 @@
     { href: '/requests', label: 'Requests', icon: 'bi-send' },
     { href: '/history', label: 'History', icon: 'bi-clock-history' },
     { href: '/tokens', label: 'Tokens', icon: 'bi-key' },
+    { href: '/agents', label: 'Agents', icon: 'bi-robot' },
     { href: '/about', label: 'About', icon: 'bi-info-circle' },
   ];
 
@@ -126,12 +127,7 @@
     {:else}
       <!-- API endpoints search + list -->
       <div class="p-3 border-top">
-        <input
-          type="text"
-          class="form-control mb-2"
-          placeholder="Search endpoints..."
-          bind:value={$searchQuery}
-        />
+        <input type="text" class="form-control mb-2" placeholder="Search endpoints..." bind:value={$searchQuery} />
         <select class="form-select" bind:value={$selectedScope}>
           <option value="">All Scopes</option>
           {#each scopes as scope}

--- a/src/routes/agents/+page.svelte
+++ b/src/routes/agents/+page.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import NavigationBar from '$lib/components/NavigationBar.svelte';
+</script>
+
+<svelte:head>
+  <title>Agents - FreeFeed API Explorer</title>
+</svelte:head>
+
+<NavigationBar currentPage="agents" />
+
+<div class="container py-2">
+  <div class="row justify-content-center">
+    <div class="col-lg-8">
+      <div class="card">
+        <div class="card-header">
+          <h3 class="mb-0">For LLM Agents</h3>
+        </div>
+        <div class="card-body">
+          <p class="lead">
+            This site supports the
+            <a href="https://llmstxt.org/" target="_blank" rel="noopener noreferrer" class="text-decoration-none">
+              llms.txt standard
+            </a>
+            to help LLM agents discover and consume the FreeFeed API reference.
+          </p>
+
+          <p>
+            Two markdown files are served at the site root with the full FreeFeed API reference in a format suitable for
+            language models:
+          </p>
+
+          <ul>
+            <li>
+              <a href="/llms.txt" class="text-decoration-none"><code>/llms.txt</code></a>
+              &mdash; concise index of available endpoints
+            </li>
+            <li>
+              <a href="/llms-full.txt" class="text-decoration-none"><code>/llms-full.txt</code></a>
+              &mdash; full API reference with endpoint details
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/routes/agents/+page.svelte
+++ b/src/routes/agents/+page.svelte
@@ -32,7 +32,7 @@
           <ul>
             <li>
               <a href="/llms.txt" class="text-decoration-none"><code>/llms.txt</code></a>
-              &mdash; concise index of available endpoints
+              &mdash; short site description with a pointer to the full reference
             </li>
             <li>
               <a href="/llms-full.txt" class="text-decoration-none"><code>/llms-full.txt</code></a>


### PR DESCRIPTION
## Summary

- New `/agents` page (between Tokens and About) that announces support for the [llms.txt standard](https://llmstxt.org/) and links to the existing `/llms.txt` and `/llms-full.txt` outputs.
- Adds the entry to both the top navbar and the mobile drawer (with a `bi-robot` icon).
